### PR TITLE
Fixes for go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/asmaloney/naming-language-gen
+module github.com/Flokey82/naming-language-gen
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Flokey82/naming-language-gen
 
-go 1.16
+go 1.18
+
+require github.com/dlclark/regexp2 v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/dlclark/regexp2 v1.8.0 h1:rJD5HeGIT/2b5CDk63FVCwZA3qgYElfg+oQK7uH5pfE=
+github.com/dlclark/regexp2 v1.8.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/asmaloney/naming-language-gen/naming"
+	"github.com/Flokey82/naming-language-gen/naming"
 )
 
 func main() {


### PR DESCRIPTION
- module path was still pointing to asmaloney
- code requires generics (go-1.18) but was set to 1.16

(Found bug attempting to build genworldvoronoi)